### PR TITLE
Add timeout when reading sites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kasp3r/link-preview",
+    "name": "freegle/link-preview",
     "type": "library",
     "description": "Link preview library for PHP",
     "keywords": ["php","url","scraping"],

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7.4.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.2|^7.4.5"
+        "guzzlehttp/guzzle": "^7.4.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3"

--- a/src/LinkPreview/Reader/GeneralReader.php
+++ b/src/LinkPreview/Reader/GeneralReader.php
@@ -27,7 +27,8 @@ class GeneralReader implements ReaderInterface
     public function getClient()
     {
         if (!$this->client) {
-            $this->client = new Client([RequestOptions::COOKIES => true]);
+            // Add a 30s timeout as a fallback - some sites block us indefinitely and never return.
+            $this->client = new Client([RequestOptions::COOKIES => true, timeout => 30]);
         }
 
         return $this->client;


### PR DESCRIPTION
Some sites (e.g. https://www.superdrug.com in my case) hang the HTTP request and don't return in a reasonable time.  Perhaps this is some anti-DoS measure.  

This PR adds a simplistic 30s fallback timer to avoid the code hanging indefinitely.